### PR TITLE
ビルド時のエラーを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 vendor
+
+# IDE
+.project
+.settings

--- a/lz4msgpack.go
+++ b/lz4msgpack.go
@@ -22,8 +22,8 @@ const (
 )
 
 // Marshal returns bytes that is the MessagePack encoded and lz4 compressed.
-func Marshal(v ...interface{}) ([]byte, error) {
-	data, err := msgpack.Marshal(v...)
+func Marshal(v interface{}) ([]byte, error) {
+	data, err := msgpack.Marshal(v)
 	if err != nil {
 		return data, err
 	}
@@ -31,10 +31,10 @@ func Marshal(v ...interface{}) ([]byte, error) {
 }
 
 // MarshalAsArray returns bytes as array format.
-func MarshalAsArray(v ...interface{}) ([]byte, error) {
+func MarshalAsArray(v interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := msgpack.NewEncoder(&buf).StructAsArray(true)
-	err := enc.Encode(v...)
+	err := enc.Encode(v)
 	if err != nil {
 		return buf.Bytes(), err
 	}
@@ -61,14 +61,14 @@ func compress(data []byte) ([]byte, error) {
 // Unmarshal decodes the MessagePack-encoded data and stores the result
 // in the value pointed to by v.
 // In case of data compressed by lz4, it will be uncompressed before decode.
-func Unmarshal(data []byte, v ...interface{}) error {
+func Unmarshal(data []byte, v interface{}) error {
 	if data[offsetCodeExt32] != msgpackCodeExt32 || data[offsetCodeLz4] != extCodeLz4 {
-		return msgpack.Unmarshal(data, v...)
+		return msgpack.Unmarshal(data, v)
 	}
 	buf := make([]byte, binary.BigEndian.Uint32(data[offsetUncompressSize:offsetLength]))
 	_, err := lz4.UncompressBlock(data[offsetLength:], buf)
 	if err != nil {
 		return err
 	}
-	return msgpack.Unmarshal(buf, v...)
+	return msgpack.Unmarshal(buf, v)
 }

--- a/lz4msgpack_test.go
+++ b/lz4msgpack_test.go
@@ -26,7 +26,6 @@ func Test(t *testing.T) {
 		b, _ := marshaler(&data)
 		t.Logf("%s: %d", name, len(b))
 		var data1 Data
-		//lz4msgpack.Unmarshal(b, &data1)
 		unmarshaler(b, &data1)
 		if !reflect.DeepEqual(data, data1) {
 			t.Fatal(name + " Error")

--- a/lz4msgpack_test.go
+++ b/lz4msgpack_test.go
@@ -22,17 +22,18 @@ func Test(t *testing.T) {
 	}
 	t.Log(data)
 
-	tester := func(name string, marshaler func(v ...interface{}) ([]byte, error)) {
+	tester := func(name string, marshaler func(v interface{}) ([]byte, error), unmarshaler func(data []byte, v interface{}) error) {
 		b, _ := marshaler(&data)
 		t.Logf("%s: %d", name, len(b))
 		var data1 Data
-		lz4msgpack.Unmarshal(b, &data1)
+		//lz4msgpack.Unmarshal(b, &data1)
+		unmarshaler(b, &data1)
 		if !reflect.DeepEqual(data, data1) {
 			t.Fatal(name + " Error")
 		}
 	}
 
-	tester("          msgpack.Marshal", msgpack.Marshal)
-	tester("       lz4msgpack.Marshal", lz4msgpack.Marshal)
-	tester("lz4msgpack.MarshalAsArray", lz4msgpack.MarshalAsArray)
+	tester("          msgpack.Marshal", msgpack.Marshal, msgpack.Unmarshal)
+	tester("       lz4msgpack.Marshal", lz4msgpack.Marshal, lz4msgpack.Unmarshal)
+	tester("lz4msgpack.MarshalAsArray", lz4msgpack.MarshalAsArray, lz4msgpack.Unmarshal)
 }


### PR DESCRIPTION
dep等での取得時にエラーになるため、テストファイルを含めて修正しました。
>go test
# github.com/d-o-n-u-t-s/lz4msgpack
.\lz4msgpack.go:26:30: invalid use of ... in call to msgpack.Marshal
.\lz4msgpack.go:37:19: invalid use of ... in call to enc.Encode
.\lz4msgpack.go:66:27: invalid use of ... in call to msgpack.Unmarshal
.\lz4msgpack.go:73:26: invalid use of ... in call to msgpack.Unmarshal
FAIL    github.com/d-o-n-u-t-s/lz4msgpack [build failed]

修正後
>go test
PASS
ok      github.com/d-o-n-u-t-s/lz4msgpack       0.776s