### PR TITLE
unmarshalの際にext format familyに対応する

### DIFF
--- a/lz4msgpack.go
+++ b/lz4msgpack.go
@@ -76,10 +76,11 @@ func unmarshal(data []byte, v interface{}, unmarshaler func([]byte, interface{})
 	if data[typeCodeOffset] != extCodeLz4 {
 		return unmarshaler(data, v)
 	}
-	bufStartOffset := typeCodeOffset + 2
-	buffEndOffset := bufStartOffset + 4
-	buf := make([]byte, binary.BigEndian.Uint32(data[bufStartOffset:buffEndOffset]))
-	_, err := lz4.UncompressBlock(data[buffEndOffset:], buf)
+	// typecode,messagePackCode:int32,dataLength(int32) で入ってる
+	lz4DataLengthOffset := typeCodeOffset + 2
+	lz4DataLengthEndOffset := lz4DataLengthOffset + 4
+	buf := make([]byte, binary.BigEndian.Uint32(data[lz4DataLengthOffset:lz4DataLengthEndOffset]))
+	_, err := lz4.UncompressBlock(data[lz4DataLengthEndOffset:], buf)
 	if err != nil {
 		return err
 	}

--- a/lz4msgpack_test.go
+++ b/lz4msgpack_test.go
@@ -76,14 +76,14 @@ func Test(t *testing.T) {
 }
 
 func TestExtUnmarshal(t *testing.T) {
-	data := "qwertyuioppasdfghjkl;'zxcvbnm,../"
+	data := "qwertyuioppasdfghjkl;'zxcvbnm,./"
 	msgpackData, err := msgpack.Marshal(data)
 	if err != nil {
 		t.Fatal("msgpack", err)
 	}
+	msgpackLength := len(msgpackData)
 
-	lz4MaxLength := lz4.CompressBlockBound(len(msgpackData))
-	lz4Data := make([]byte, lz4MaxLength)
+	lz4Data := make([]byte, lz4.CompressBlockBound(msgpackLength))
 	lz4Length, _ := lz4.CompressBlockHC(msgpackData, lz4Data, 0, nil, nil)
 	if err != nil {
 		t.Fatal("lz4", err)
@@ -91,7 +91,7 @@ func TestExtUnmarshal(t *testing.T) {
 
 	// ext8
 	ext8 := []byte{0xc7, 0, 99, 0xd2}
-	ext8 = binary.BigEndian.AppendUint32(ext8, uint32(lz4MaxLength))
+	ext8 = binary.BigEndian.AppendUint32(ext8, uint32(msgpackLength))
 	ext8 = append(ext8, lz4Data...)
 	var ext8umarshaled string
 	if err = lz4msgpack.Unmarshal(ext8[:8+lz4Length], &ext8umarshaled); err != nil {
@@ -103,7 +103,7 @@ func TestExtUnmarshal(t *testing.T) {
 
 	// ext16
 	ext16 := []byte{0xc8, 0, 0, 99, 0xd2}
-	ext16 = binary.BigEndian.AppendUint32(ext16, uint32(lz4MaxLength))
+	ext16 = binary.BigEndian.AppendUint32(ext16, uint32(msgpackLength))
 	ext16 = append(ext16, lz4Data...)
 	var ext16umarshaled string
 	if err = lz4msgpack.Unmarshal(ext16[:9+lz4Length], &ext16umarshaled); err != nil {
@@ -115,7 +115,7 @@ func TestExtUnmarshal(t *testing.T) {
 
 	// ext32
 	ext32 := []byte{0xc9, 0, 0, 0, 0, 99, 0xd2}
-	ext32 = binary.BigEndian.AppendUint32(ext32, uint32(lz4MaxLength))
+	ext32 = binary.BigEndian.AppendUint32(ext32, uint32(msgpackLength))
 	ext32 = append(ext32, lz4Data...)
 	var ext32umarshaled string
 	if err = lz4msgpack.Unmarshal(ext32[:11+lz4Length], &ext32umarshaled); err != nil {

--- a/lz4msgpack_test.go
+++ b/lz4msgpack_test.go
@@ -95,10 +95,10 @@ func TestExtUnmarshal(t *testing.T) {
 	ext8 = append(ext8, lz4Data...)
 	var ext8umarshaled string
 	if err = lz4msgpack.Unmarshal(ext8[:8+lz4Length], &ext8umarshaled); err != nil {
-		t.Fatal("unmarshal", err)
+		t.Fatal("unmarshal ext8", err)
 	}
 	if !reflect.DeepEqual(data, ext8umarshaled) {
-		t.Fatal("error")
+		t.Fatal("error ext8")
 	}
 
 	// ext16
@@ -107,10 +107,10 @@ func TestExtUnmarshal(t *testing.T) {
 	ext16 = append(ext16, lz4Data...)
 	var ext16umarshaled string
 	if err = lz4msgpack.Unmarshal(ext16[:9+lz4Length], &ext16umarshaled); err != nil {
-		t.Fatal("unmarshal", err)
+		t.Fatal("unmarshal ext16", err)
 	}
 	if !reflect.DeepEqual(data, ext16umarshaled) {
-		t.Fatal("error")
+		t.Fatal("error ext16")
 	}
 
 	// ext32
@@ -119,9 +119,9 @@ func TestExtUnmarshal(t *testing.T) {
 	ext32 = append(ext32, lz4Data...)
 	var ext32umarshaled string
 	if err = lz4msgpack.Unmarshal(ext32[:11+lz4Length], &ext32umarshaled); err != nil {
-		t.Fatal("unmarshal", err)
+		t.Fatal("unmarshal ext32", err)
 	}
 	if !reflect.DeepEqual(data, ext32umarshaled) {
-		t.Fatal("error")
+		t.Fatal("error ext32")
 	}
 }


### PR DESCRIPTION
msgpack c# v2系でext8,ext16のフォーマットで送られるように最適化が入ったのでgo側も対応(unmarshal時のみ)